### PR TITLE
Fix chat WebSocket connect

### DIFF
--- a/broadcast/settings.py
+++ b/broadcast/settings.py
@@ -60,6 +60,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'channels',
     'rest_framework',
     'users',
     'chat',

--- a/chat/static/chat/js/chat.js
+++ b/chat/static/chat/js/chat.js
@@ -23,10 +23,13 @@ document.addEventListener("DOMContentLoaded", () => {
   };
 
   sendBtn.onclick = () => {
-    if (msgInput.value.trim() !== "") {
-      socket.send(JSON.stringify({ message: msgInput.value }));
-      msgInput.value = "";
+    if (msgInput.value.trim() === "") return;
+    if (socket.readyState !== WebSocket.OPEN) {
+      console.warn("WebSocket is not open");
+      return;
     }
+    socket.send(JSON.stringify({ message: msgInput.value }));
+    msgInput.value = "";
   };
 
   if (uploadBtn) {


### PR DESCRIPTION
## Summary
- register `channels` in installed apps
- ensure the chat JS checks WebSocket state before sending messages

## Testing
- `python manage.py test` *(fails: No module named 'django')*