### PR TITLE
Redirect to Jitsi room

### DIFF
--- a/meetings/templates/meetings/jitsi_redirect.html
+++ b/meetings/templates/meetings/jitsi_redirect.html
@@ -1,0 +1,21 @@
+{% extends 'users/base.html' %}
+{% block title %}{{ meeting.title }} - Redirect{% endblock %}
+{% block content %}
+<div class="container py-5">
+  <h3>{{ meeting.title }}</h3>
+  <p>Вы были переадресованы на сервис Jitsi Meet.</p>
+  <p>Если новая вкладка не открылась автоматически, перейдите по ссылке:
+    <a href="{{ meeting.jitsi_url }}" target="_blank" id="jitsi-link">{{ meeting.jitsi_url }}</a>
+  </p>
+  <p>После завершения встречи вернитесь на эту страницу.</p>
+  <a href="{% url 'home' %}" class="btn btn-primary mt-3">На главную</a>
+</div>
+<script>
+  window.addEventListener('DOMContentLoaded', () => {
+    const opened = window.open('{{ meeting.jitsi_url }}', '_blank');
+    if (!opened) {
+      document.getElementById('jitsi-link').style.fontWeight = 'bold';
+    }
+  });
+</script>
+{% endblock %}

--- a/meetings/test.py
+++ b/meetings/test.py
@@ -39,3 +39,4 @@ class MeetingsTests(TestCase):
         j = self.client.get(reverse('meetings:join', kwargs={'slug': m.room_name}))
         self.assertEqual(j.status_code, 200)
         self.assertContains(j, m.title)
+        self.assertContains(j, m.jitsi_url)

--- a/meetings/views.py
+++ b/meetings/views.py
@@ -70,14 +70,14 @@ class MeetingDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
 
 
 class MeetingJoinView(View):
-    """Opens the Jitsi meeting in an embedded page."""
+    """Redirects the user to the Jitsi service in a new tab."""
 
     def get(self, request, slug):
         meeting = get_object_or_404(Meeting, room_name=slug)
         if request.user.is_authenticated and request.user != meeting.host \
            and not meeting.participants.filter(pk=request.user.pk).exists():
             meeting.participants.add(request.user)
-        return render(request, 'meetings/jitsi.html', {
+        return render(request, 'meetings/jitsi_redirect.html', {
             'meeting': meeting,
             'jitsi_domain': settings.JITSI_DOMAIN,
         })


### PR DESCRIPTION
## Summary
- update join view to redirect to external Jitsi URL
- add redirect page template
- update tests accordingly

## Testing
- `python manage.py test` *(fails: ImportError: No module named 'django')*